### PR TITLE
Merge remote-tracking branch 'refs/remotes/origin/chess-lib' into chess-lib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.86.0
           profile: minimal
           override: true
           components: rustfmt, clippy

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,12 +4,12 @@
   "version": "0.1.0",
   "type": "module",
   "workspaces": [
-    "frontend",
+    ".",
     "wasm"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "pnpm build:wasm && tsc -b && vite build",
+    "build": "pnpm -r run build && tsc -b && vite build",
     "build:wasm": "cd wasm && bash build.bash --release",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - wasm
-  - frontend
+  - .

--- a/frontend/src/hooks/useWasm.ts
+++ b/frontend/src/hooks/useWasm.ts
@@ -5,7 +5,7 @@ import init, {
   update_board,
   get_board,
   get_game_state,
-} from 'wasm/pkg'
+} from 'wasm'
 
 type ChessWasm = {
   isLoading: boolean

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,4 +19,7 @@ export default defineConfig({
     wasm() as PluginOption,
     topLevelAwait(),
   ],
+  optimizeDeps: {
+    exclude: ['@wasm'],
+  },
 })

--- a/frontend/wasm/package.json
+++ b/frontend/wasm/package.json
@@ -4,6 +4,13 @@
   "main": "pkg/wasm.js",
   "types": "pkg/wasm.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./pkg/wasm.js",
+      "types": "./pkg/wasm.d.ts"
+    },
+    "./pkg/*": "./pkg/*"
+  },
   "files": [
     "pkg"
   ],


### PR DESCRIPTION
fix bin/test.rs used for manual testing and development of chess_lib, and additional monorepo correctness