### PR TITLE
feat(frontend): add vercel-build script for wasm compilation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "pnpm -r run build && tsc -b && vite build",
+    "vercel-build": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && pnpm build:wasm && tsc -b && vite build",
     "build:wasm": "cd wasm && bash build.bash --release",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",


### PR DESCRIPTION
Add a new "vercel-build" script that installs Rust toolchain and builds WASM modules before running the standard build process. This enables proper deployment to Vercel with Rust WASM support.